### PR TITLE
Fixed typographical error, changed abondoned to abandoned in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MultiSync.configure do |config|
   # config.force = false  # force syncing of outdated_files (defaults to false)
   # config.run_on_build = true # when within a framework which `builds` assets, whether to sync afterwards (defaults to true)
   # config.sync_outdated_files = true # when an outdated file is found whether to replace it (defaults to true)
-  # config.delete_abandoned_files = true # when an abondoned file is found whether to remove it (defaults to true)
+  # config.delete_abandoned_files = true # when an abandoned file is found whether to remove it (defaults to true)
   # config.upload_missing_files = true # when a missing file is found whether to upload it (defaults to true)
   # config.target_pool_size = 8 # how many threads you would like to open for each target (defaults to the amount of CPU core's your machine has)
   # config.max_sync_attempts = 3 # how many times a file should be retried if there was an error during sync (defaults to 3)


### PR DESCRIPTION
karlfreeman, I've corrected a typographical error in the documentation of the [multi_sync](https://github.com/karlfreeman/multi_sync) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.