### PR TITLE
make `fog` an optional dependency

### DIFF
--- a/multi_sync.gemspec
+++ b/multi_sync.gemspec
@@ -24,9 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'celluloid', '~> 0.16'
   spec.add_dependency 'multi_mime', '~> 1.0'
 
-  # must be installed via meta-package in bundler
-  spec.add_optional_dependency 'fog', '~> 1.2'  
-  
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'kramdown', '>= 0.14'

--- a/multi_sync.gemspec
+++ b/multi_sync.gemspec
@@ -18,13 +18,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 1.9.3'
-
-  spec.add_dependency 'fog', '~> 1.2'
+  
   spec.add_dependency 'unf'
   spec.add_dependency 'virtus', '~> 1.0'
   spec.add_dependency 'celluloid', '~> 0.16'
   spec.add_dependency 'multi_mime', '~> 1.0'
 
+  # must be installed via meta-package in bundler
+  spec.add_optional_dependency 'fog', '~> 1.2'  
+  
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'kramdown', '>= 0.14'


### PR DESCRIPTION
By allowing fog to be specified as a 'peer dependency', users can avoid _30_ potentially unnecessary gem dependencies on services that are unused. If you agree with this, I can put together a full PR with documentation changes as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/karlfreeman/multi_sync/5)
<!-- Reviewable:end -->
